### PR TITLE
allow tempfiles to have a suffix like .s or .o

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -40,7 +40,7 @@
 #endif
 
 #ifndef ASSEMBLER
-#define ASSEMBLER "gcc -c -xassembler"
+#define ASSEMBLER "gcc -c"
 #endif
 
 #ifndef COMPILER_INCLUDE_DIR
@@ -870,7 +870,7 @@ again:
 			if (mode == MODE_COMPILE) {
 				asm_out = out;
 			} else {
-				asm_out = make_temp_file("ccs", &unit->name);
+				asm_out = make_temp_file(".s", &unit->name);
 			}
 			ir_timer_t *t_opt_codegen = ir_timer_new();
 			timer_register(t_opt_codegen, "Optimization and Codegeneration");
@@ -897,7 +897,7 @@ again:
 				fclose(out);
 				unit->name = outname;
 			} else {
-				FILE *tempf = make_temp_file("cco", &unit->name);
+				FILE *tempf = make_temp_file(".o", &unit->name);
 				/* hackish... */
 				fclose(tempf);
 			}

--- a/enable_posix.h
+++ b/enable_posix.h
@@ -26,9 +26,10 @@
 
 #else
 #define _POSIX_C_SOURCE 200809L
+#define _BSD_SOURCE
 #include <unistd.h>
 #include <sys/stat.h>
-#define HAVE_MKSTEMP
+#define HAVE_MKSTEMPS
 #define HAVE_FILENO
 #define HAVE_ASCTIME_R
 #define HAVE_FSTAT

--- a/tempfile.h
+++ b/tempfile.h
@@ -7,7 +7,7 @@
  * custom version of tmpnam, which: writes to an obstack, emits no warnings
  * during linking (like glibc/gnu ld do for tmpnam)...
  */
-FILE *make_temp_file(const char *prefix, const char **name_result);
+FILE *make_temp_file(const char *suffix, const char **name_result);
 
 void init_temp_files(void);
 void free_temp_files(void);


### PR DESCRIPTION
This allows the compiler to know what to do with file
without any extra option. The main advantage is that you
can now use cparser with any compiler, and not just GCC.
