### PR TITLE
(fix) - correct reference to sub-module `libfirm`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libfirm"]
 	path = libfirm
-	url = https://pp.info.uni-karlsruhe.de/git/libfirm.git/
+	url = ../libfirm.git
+


### PR DESCRIPTION
This pull request fixes the reference to the sub-module `libfirm` to be a relative path to `cparser`.